### PR TITLE
Add an App struct and use gtk::Application::startup only for creating…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Sebastian Dröge <sebastian@centricular.com>", "Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 [dependencies]
-gtk = "0.5"
+gtk = { version = "0.5", features = ["v3_6"] }
 gio = "0.5"


### PR DESCRIPTION
… the menu and window

The window is shown/presented only in gtk::Application::activate, which
also has the side-effect that when a second instance of the application
is started only the window of the first instance is brought to the
foreground.

----

CC @GuillaumeGomez 